### PR TITLE
Export Common Utility Functions for Metadata and Resource Names

### DIFF
--- a/common/utils.k
+++ b/common/utils.k
@@ -1,0 +1,42 @@
+import crypto
+
+# Generates a Kubernetes-compliant resource name from id and suffix, keeping readability when truncated
+# @param baseId The base identifier
+# @param suffix The suffix to append to the base name
+# @return A string containing the generated Kubernetes resource name
+_generateKubernetesResourceName = lambda baseId: str, suffix: str -> str {
+    _baseName = ""
+    if suffix == "":
+        _baseName = baseId
+    else:
+        _baseName = baseId + "-" + suffix
+    # If name exceeds 63 characters, truncate and add hash for uniqueness
+    if len(_baseName) > 63:
+        # Keep first 30 characters of original name + "-" + 32 chars MD5 hash = 63 total
+        _truncatedName = _baseName[:30:]
+        _hashSuffix = crypto.md5(_baseName)
+        _baseName = _truncatedName + "-" + _hashSuffix
+
+    _baseName
+}
+# Creates metadata for a Kubernetes resource with a composition resource name annotation
+#
+# @param id - The identifier of the resource
+# @param kind - The kind of the resource (e.g. "virtualnetwork")
+# @param suffix - The suffix to append to the resource name
+# @return - A metadata object with appropriate annotations and name
+_metadata = lambda id: str, kind: str, suffix: str -> any {
+    {
+        annotations = {
+            if suffix == "":
+                "krm.kcl.dev/composition-resource-name" = id + "-" + kind
+            else:
+                # Use the suffix to create a unique name for the resource
+                # This is useful for resources that are created multiple times
+                # with different suffixes (e.g. subnets)
+                # The suffix is used to differentiate between different resources
+                "krm.kcl.dev/composition-resource-name" = id + "-" + kind + "-" + suffix
+        }
+        name = _generateKubernetesResourceName(id, suffix)
+    }
+}

--- a/io/utils.k
+++ b/io/utils.k
@@ -1,0 +1,15 @@
+# Re-export metadata utilities for external consumption
+import common.metadata as _meta
+
+# Generates a Kubernetes-compliant resource name from id and suffix, keeping readability when truncated
+# @param baseId The base identifier
+# @param suffix The suffix to append to the base name
+# @return A string containing the generated Kubernetes resource name
+generateKubernetesResourceName = _meta._generateKubernetesResourceName
+# Creates metadata for a Kubernetes resource with a composition resource name annotation
+#
+# @param id - The identifier of the resource
+# @param kind - The kind of the resource (e.g. "virtualnetwork")
+# @param suffix - The suffix to append to the resource name
+# @return - A metadata object with appropriate annotations and name
+metadata = _meta._metadata

--- a/kcl.mod
+++ b/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "models"
-version = "0.0.3"
+version = "0.0.4"
 include = ["io/", "k8s/", "common/"]

--- a/kcl.mod
+++ b/kcl.mod
@@ -1,4 +1,4 @@
 [package]
 name = "models"
 version = "0.0.3"
-include = ["io/", "k8s/"]
+include = ["io/", "k8s/", "common/"]


### PR DESCRIPTION
This pull request exports utility functions for generating Kubernetes-compliant resource names and creating resource metadata annotations, making them available for external KCL clients. The version is incremented to 0.0.4 to reflect these enhancements.

**Key changes:**
- Utility functions for resource name generation and metadata creation are now accessible from the package
- Documentation/examples provided for usage in external KCL projects

Closes #9